### PR TITLE
Removing the slf4j-log4j dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ project(':shellbase-core') {
     dependencies {
         implementation "joda-time:joda-time:${jodaTimeVersion}"
         implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-        implementation "org.slf4j:slf4j-log4j12:${slf4jVersion}"
         implementation "commons-cli:commons-cli:${commonsCliVersion}"
         implementation "commons-io:commons-io:${commonsIoVersion}"
         implementation "jline:jline:${jlineVersion}"


### PR DESCRIPTION
The trigger for the change is obviously the log4j saga that recently popped up.

The reason for removing this dependency is simple. I don't think a library like this should depend on the specific slf4j provider (here a log4j slf4j provider). Users of the library could/should pick their own slf4j provider.