### PR TITLE
SlackState.userNameToBeUsedWhenPosting instead of slackOptions

### DIFF
--- a/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/PostToSlackHelper.scala
+++ b/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/PostToSlackHelper.scala
@@ -26,7 +26,7 @@ import slack.models.{Attachment, Block}
 trait PostToSlackHelper {
   protected val slackState: SlackState
 
-  protected val username: String = System.getProperty("user.name", "unknown")
+  protected def username: String = System.getProperty("user.name", "unknown")
   protected val excludedUsernames: Set[String] = Set.empty
 
   def slackMessagingConfigured: Boolean = slackState.slackClient.isDefined && slackState.slackChannels.nonEmpty
@@ -52,6 +52,7 @@ trait PostToSlackHelper {
       for (client <- slackState.slackClient;
            channel <- slackState.slackChannels.filter(slackChannelFilter)) {
         val username: Option[String] = additionalOptions.get("username")
+          .orElse(Some(slackState.userNameToBeUsedWhenPosting))
         val asUser: Option[Boolean] = additionalOptions.get("as_user").map(_.toBoolean)
         val parse: Option[String] = additionalOptions.get("parse")
         val linkNames: Option[String] = additionalOptions.get("link_names")

--- a/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/SlackState.scala
+++ b/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/SlackState.scala
@@ -30,5 +30,5 @@ trait SlackState {
 
   def actorSystem: ActorSystem
 
-  def userNameToBeUsedWhenPosting: String
+  def userNameToBeUsedWhenPosting: String = "shell"
 }

--- a/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/SlackState.scala
+++ b/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/SlackState.scala
@@ -28,7 +28,7 @@ trait SlackState {
 
   def slackChannels: List[String] = slackChannel.toList
 
-  def slackOptions: Map[String, String] = Map()
-
   def actorSystem: ActorSystem
+
+  def userNameToBeUsedWhenPosting: String
 }

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandToSlackTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandToSlackTest.scala
@@ -147,8 +147,8 @@ class PostCommandToSlackTest extends CommonWordSpec with BeforeAndAfterEach with
     when(mockState.slackClient).thenReturn(None)
     when(mockState.slackChannel).thenReturn(None)
     when(mockState.slackChannels).thenReturn(None.toList)
-    when(mockState.slackOptions).thenReturn(Map.empty[String, String])
     when(mockState.actorSystem).thenReturn(mock[ActorSystem])
+    when(mockState.userNameToBeUsedWhenPosting).thenReturn("MY_SHELL")
 
     sut = new ShellCommand("", "") with PostCommandToSlack {
       override protected val slackState: SlackState = mockState

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
@@ -169,8 +169,8 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
     when(mockState.slackClient).thenReturn(None)
     when(mockState.slackChannel).thenReturn(None)
     when(mockState.slackChannels).thenReturn(None.toList)
-    when(mockState.slackOptions).thenReturn(Map.empty[String, String])
     when(mockState.actorSystem).thenReturn(mock[ActorSystem])
+    when(mockState.userNameToBeUsedWhenPosting).thenReturn("MY_SHELL")
 
     sut = new ShellCommand("", "") with PostCommandWithSlackThread {
       override protected val slackState: SlackState = mockState


### PR DESCRIPTION
## Three changes
1. Removing `SlackState.slackOptions` as they were not read anywhere (outside of tests). Some unfinished feature?
2. Converting  `PostToSlackHelper. username` to a `def` in order to allow taking the information on current user name from a different source than a System property.
3. Adding `SlackState.userNameToBeUsedWhenPosting`, so that one can make sure the Slack messages posted by the shell have its name as the user name, e.g.
 with
```
override def userNameToBeUsedWhenPosting: String = "OurPrivateShell"
```
you get:
![image](https://user-images.githubusercontent.com/762437/151782076-55ae9a49-c284-46d9-8cea-872a87139cfb.png)

Notice: the notion of username in bullet no. 2 and no. 3 are different user names. No 2 has **shell user name** (typically your local machine user name). No 3 has **Slack user name** to be used by Shell for posting to Slack.

## Testing performed
- I've used the snapshot JAR with one of our internal shells to run a simple command posting to Slack.