### PR TITLE
Moving the dependency version properties to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,20 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1"
     }
+
+    // NOTE(mccartney, 2022-07-11): Keeping these versions here works with Dependabot. Moving to gradle.properties does not.
+    ext.akkaVersion = '2.5.25'
+    ext.awsSdkVersion = '1.11.980'
+    ext.commonsCliVersion = '1.4'
+    ext.commonsIoVersion = '2.8.0'
+    ext.jlineVersion = '2.14.6'
+    ext.jodaTimeVersion = '2.10.10'
+    ext.junitVersion = '4.13.2'
+    ext.mockitoVersion = '3.8.0'
+    ext.scalaSlackClientVersion = '0.2.14'
+    ext.scalatestVersion = '3.0.9'
+    ext.slf4jVersion = '1.7.12'
+    ext.velocityVersion = '1.7'
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,19 +13,6 @@ javaTargetVersion = 1.8
 supportedScalaVersions = 2.11.12, 2.12.15, 2.13.8
 defaultScalaVersion = 2.11.12
 
-# Dependencies versions
-akkaVersion = 2.5.25
-awsSdkVersion = 1.11.980
-commonsCliVersion = 1.4
-commonsIoVersion = 2.8.0
-jlineVersion = 2.14.6
-jodaTimeVersion = 2.10.10
-junitVersion = 4.13.2
-mockitoVersion = 3.8.0
-scalaSlackClientVersion = 0.2.14
-scalatestVersion = 3.0.9
-slf4jVersion = 1.7.12
-velocityVersion = 1.7
 
 # Gradle UI
 systemProp.org.gradle.color.info=YELLOW


### PR DESCRIPTION
... so that @Dependabot (added in #68) can pick them up.
