### PR TITLE
Adding support for comments which are posted to Slack

### DIFF
--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandTest.scala
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.shellbase
+
+import org.apache.commons.cli.CommandLine
+import org.junit.runner.RunWith
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ShellCommandTest extends CommonWordSpec {
+  "ShellCommand" should {
+    "parse comments" in {
+      sut().extractPossibleComments(List("")) shouldBe((List(""), None))
+      sut().extractPossibleComments(List("foo","show", "-bar", "-p", "a;c:1")) shouldBe(
+        (List("foo", "show", "-bar", "-p", "a;c:1"), None))
+      sut().extractPossibleComments(List("live", "a", "happy", "life")) shouldBe(
+        (List("live", "a", "happy", "life"), None))
+      sut().extractPossibleComments(List("live", "a", "happy", "life", "#", "and", "don't", "regret", "anything")) shouldBe(
+        (List("live", "a", "happy", "life"), Some("and don't regret anything")))
+    }
+  }
+
+  def sut() = {
+    new ShellCommand("do", "Does the thing") {
+      override def execute(cmdLine: CommandLine): Boolean = true
+    }
+  }
+}

--- a/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThread.scala
+++ b/shellbase-slack/src/main/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThread.scala
@@ -27,11 +27,12 @@ trait PostCommandWithSlackThread extends PostCommandToSlack {
   // 5 minutes as default
   protected val commandNotifyUserTimeThresholdInMinute: Int = 5
 
-  override def postCommandToSlack(commandPath: List[String], arguments: List[String]): Option[String] = {
+  override def postCommandToSlack(commandPath: List[String], arguments: List[String],
+                                  comments: Option[String]): Option[String] = {
     try {
       var tsOpt: Option[String] = None
       retry(maxAttempts = 3, sleepTime = 1000) {
-        for (msg <- slackMessage(commandPath, arguments)) {
+        for (msg <- slackMessage(commandPath, arguments, comments)) {
           tsOpt = sendSlackMessageIfConfigured(s"[$username] $msg")
         }
         tsOpt

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
@@ -34,19 +34,19 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
 
   "PostCommandWithSlackThreads" should {
     "do nothing when no client or channel is provided" in {
-      sut.postCommandToSlack(List.empty, List.empty) should be(None)
+      sut.postCommandToSlack(List.empty, List.empty, None) should be(None)
       sut.slackMessagingConfigured should be(false)
     }
 
     "do nothing with a client but no channel" in {
       createMockClient
-      sut.postCommandToSlack(List.empty, List.empty) should be(None)
+      sut.postCommandToSlack(List.empty, List.empty, None) should be(None)
       sut.slackMessagingConfigured should be(false)
     }
 
     "do nothing with a channel but no client" in {
       createAChannel
-      sut.postCommandToSlack(List.empty, List.empty) should be(None)
+      sut.postCommandToSlack(List.empty, List.empty, None) should be(None)
       sut.slackMessagingConfigured should be(false)
     }
 
@@ -55,10 +55,10 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
       val channel = createAChannel
       sut.slackMessagingConfigured should be(true)
 
-      sut.postCommandToSlack(List("Hi"), List.empty) should be(Some(ts))
+      sut.postCommandToSlack(List("Hi"), List.empty, None) should be(Some(ts))
       verifyCallToPost(slackClient, times(1), channel)
 
-      sut.postCommandToSlack(List("Hi"), List("with", "params")) should be(Some(ts))
+      sut.postCommandToSlack(List("Hi"), List("with", "params"), None) should be(Some(ts))
       verifyCallToPost(slackClient, times(2), channel)
     }
 
@@ -67,12 +67,12 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
       val channels = createTwoChannels
       sut.slackMessagingConfigured should be(true)
 
-      sut.postCommandToSlack(List("Hi"), List.empty) should be(Some(ts))
+      sut.postCommandToSlack(List("Hi"), List.empty, None) should be(Some(ts))
       channels.foreach(channel =>
         verifyCallToPost(slackClient, times(1), channel)
       )
 
-      sut.postCommandToSlack(List("Hi"), List("with", "params")) should be(Some(ts))
+      sut.postCommandToSlack(List("Hi"), List("with", "params"), None) should be(Some(ts))
       channels.foreach(channel =>
         verifyCallToPost(slackClient, times(2), channel)
       )
@@ -84,10 +84,10 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
       createTwoChannelsAndOneFilteredOut
       sut.slackMessagingConfigured should be(true)
 
-      sut.postCommandToSlack(List("Hi"), List.empty) should be(Some(ts))
+      sut.postCommandToSlack(List("Hi"), List.empty, None) should be(Some(ts))
       verifyCallToPost(slackClient, times(0), channel)
 
-      sut.postCommandToSlack(List("Hi"), List("with", "params")) should be(Some(ts))
+      sut.postCommandToSlack(List("Hi"), List("with", "params"), None) should be(Some(ts))
       verifyCallToPost(slackClient, times(0), channel)
     }
 
@@ -98,7 +98,7 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
 
       whenPostingToChannel(slackClient, channel).thenThrow(new RuntimeException)
 
-      sut.postCommandToSlack(List.empty, List.empty) should be(None)
+      sut.postCommandToSlack(List.empty, List.empty, None) should be(None)
     }
 
     "retry and maybe eventually succeed" in {
@@ -108,7 +108,7 @@ class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterE
 
       whenPostingToChannel(slackClient, channel).thenThrow(new RuntimeException).thenReturn(ts)
 
-      sut.postCommandToSlack(List.empty, List.empty) should be(Some(ts))
+      sut.postCommandToSlack(List.empty, List.empty, None) should be(Some(ts))
       verifyCallToPost(slackClient, times(2), channel)
     }
 


### PR DESCRIPTION
Adding support for comments in the commands like this:
```
code show something important # I need it for COMP-116
```
which results in the `code show something important` command executed **and** a message incl. "I need it for COMP-116" posted to Slack

=====
There's one shortcoming of this implementation which I am aware of and that's due to how parsing of commands is done in this code. Namely, `&&` wins over comments, e.g.
```
code show something important # Don't do anything && help
```
results in these two commands executed:

- `code show something important`
- `help`

I can see two alternative solutions to the same need which wouldn't have this `&&` problem:

1. Change the parsing altogether into a robust one, with lexers, parsers, etc.
2. Move the comment extraction logic higher up - i.e. to `ShellBase.runCommand()`. This one would mean more work (and I am lazy). Also - it would most likely require some revision of expectations. Currently messages to Slack are posted for commands. If comments would be parsed to separate entities - then the Slack posting for a command wouldn't contain comments, etc.

