### PR TITLE
Dropping support for Scala 2.11;  upgrading Scala to 2.12.17 and 2.13.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,16 +27,10 @@ jobs:
         with:
           arguments: |
               build          
-              -PscalaVersion=2.12.15
+              -PscalaVersion=2.12.17
       - name: build 2.13
         uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
         with:
           arguments: |
               build          
-              -PscalaVersion=2.13.8
-      - name: build 2.13
-        uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
-        with:
-          arguments: |
-              build          
-              -PscalaVersion=2.11.12
+              -PscalaVersion=2.13.10

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To build project in default Scala version:
 
 To build project in any supported Scala version:
 ```
-./gradlew build -PscalaVersion=2.13.8
+./gradlew build -PscalaVersion=2.13.10
 ```
 
 For testing, change your consumer `pom.xml` or `gradle.properties` to depend on the `SNAPSHOT` version generated.
@@ -86,15 +86,12 @@ outside this list)
     ```
 4. Perform a release in selected Scala versions:
     ```
-    ./gradlew shellbase-example:publish -PscalaVersion=2.11.12
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.11.12
-    ./gradlew shellbase-core:publish -PscalaVersion=2.11.12
-    ./gradlew shellbase-example:publish -PscalaVersion=2.12.15
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.12.15
-    ./gradlew shellbase-core:publish -PscalaVersion=2.12.15
-    ./gradlew shellbase-example:publish -PscalaVersion=2.13.8
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.13.8
-    ./gradlew shellbase-core:publish -PscalaVersion=2.13.8
+    ./gradlew shellbase-example:publish -PscalaVersion=2.12.17
+    ./gradlew shellbase-slack:publish -PscalaVersion=2.12.17
+    ./gradlew shellbase-core:publish -PscalaVersion=2.12.17
+    ./gradlew shellbase-example:publish -PscalaVersion=2.13.10
+    ./gradlew shellbase-slack:publish -PscalaVersion=2.13.10
+    ./gradlew shellbase-core:publish -PscalaVersion=2.13.10
 
     ```
 5. Go to https://oss.sonatype.org/index.html#stagingRepositories, search for com.sumologic, close and release your repo. 

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,6 @@ buildscript {
     }
 
     // NOTE(mccartney, 2022-07-11): Keeping these versions here works with Dependabot. Moving to gradle.properties does not.
-    ext.akkaVersion = '2.5.25'
-    ext.awsSdkVersion = '1.11.980'
     ext.commonsCliVersion = '1.5.0'
     ext.commonsIoVersion = '2.11.0'
     ext.jlineVersion = '2.14.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,8 @@ javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
 # Scala versions
-supportedScalaVersions = 2.11.12, 2.12.15, 2.13.8
-defaultScalaVersion = 2.11.12
+supportedScalaVersions = 2.12.17, 2.13.10
+defaultScalaVersion = 2.12.17
 
 
 # Gradle UI


### PR DESCRIPTION
- Dropping support for Scala 2.11, fixes #77 
- Upgrading Scala 2.12 and 2.13 minor versions to latest.