### PR TITLE
slack-scala-client upgraded to 0.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.jodaTimeVersion = '2.12.1'
     ext.junitVersion = '4.13.2'
     ext.mockitoVersion = '4.8.1'
-    ext.scalaSlackClientVersion = '0.2.14'
+    ext.scalaSlackClientVersion = '0.4.0'
     ext.scalatestVersion = '3.0.9'
     ext.slf4jVersion = '2.0.3'
     ext.velocityVersion = '1.7'


### PR DESCRIPTION
slack-scala-client upgraded to 0.4.0
@Dependabot is not willing to help here most likely because of `scalaMajorVersion` variable used in `build.gradle`