### PR TITLE
slack-scala-client 1.0.1, Scala 2.12.19, Scala 2.13.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           arguments: |
               build          
-              -PscalaVersion=2.12.17
+              -PscalaVersion=2.12.19
 
   build_java11-scala2_13:
     runs-on: ubuntu-latest
@@ -47,4 +47,4 @@ jobs:
         with:
           arguments: |
               build          
-              -PscalaVersion=2.13.10
+              -PscalaVersion=2.13.14

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ outside this list)
     ```
 4. Perform a release in selected Scala versions:
     ```
-    ./gradlew shellbase-example:publish -PscalaVersion=2.12.17
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.12.17
-    ./gradlew shellbase-core:publish -PscalaVersion=2.12.17
-    ./gradlew shellbase-example:publish -PscalaVersion=2.13.10
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.13.10
-    ./gradlew shellbase-core:publish -PscalaVersion=2.13.10
+    ./gradlew shellbase-example:publish -PscalaVersion=2.12.19
+    ./gradlew shellbase-slack:publish -PscalaVersion=2.12.19
+    ./gradlew shellbase-core:publish -PscalaVersion=2.12.19
+    ./gradlew shellbase-example:publish -PscalaVersion=2.13.14
+    ./gradlew shellbase-slack:publish -PscalaVersion=2.13.14
+    ./gradlew shellbase-core:publish -PscalaVersion=2.13.14
 
     ```
 5. Go to https://oss.sonatype.org/index.html#stagingRepositories, search for com.sumologic, close and release your repo. 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.jodaTimeVersion = '2.12.7'
     ext.junitVersion = '4.13.2'
     ext.mockitoVersion = '4.8.1'
-    ext.scalaSlackClientVersion = '1.0.0'
+    ext.scalaSlackClientVersion = '1.0.1'
     ext.scalatestVersion = '3.0.9'
     ext.slf4jVersion = '2.0.16'
     ext.velocityVersion = '2.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,8 @@ javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
 # Scala versions
-supportedScalaVersions = 2.12.17, 2.13.10
-defaultScalaVersion = 2.12.17
+supportedScalaVersions = 2.12.19, 2.13.14
+defaultScalaVersion = 2.12.19
 
 
 # Gradle UI


### PR DESCRIPTION
**What**:

Upgrading:
- slack-scala-client to 1.0.1
- Scala to 2.12.19, 2.13.14

**Why**:
No specific reason. Just to say up-to-date.