### PR TITLE
Shellbase 5.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           arguments: |
               build          
-              -PscalaVersion=2.12.19
+              -PscalaVersion=2.12.20
 
   build_java11-scala2_13:
     runs-on: ubuntu-latest
@@ -47,4 +47,4 @@ jobs:
         with:
           arguments: |
               build          
-              -PscalaVersion=2.13.14
+              -PscalaVersion=2.13.15

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ outside this list)
     ```
 4. Perform a release in selected Scala versions:
     ```
-    ./gradlew shellbase-example:publish -PscalaVersion=2.12.19
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.12.19
-    ./gradlew shellbase-core:publish -PscalaVersion=2.12.19
-    ./gradlew shellbase-example:publish -PscalaVersion=2.13.14
-    ./gradlew shellbase-slack:publish -PscalaVersion=2.13.14
-    ./gradlew shellbase-core:publish -PscalaVersion=2.13.14
+    ./gradlew shellbase-example:publish -PscalaVersion=2.12.20
+    ./gradlew shellbase-slack:publish -PscalaVersion=2.12.20
+    ./gradlew shellbase-core:publish -PscalaVersion=2.12.20
+    ./gradlew shellbase-example:publish -PscalaVersion=2.13.15
+    ./gradlew shellbase-slack:publish -PscalaVersion=2.13.15
+    ./gradlew shellbase-core:publish -PscalaVersion=2.13.15
 
     ```
 5. Go to https://oss.sonatype.org/index.html#stagingRepositories, search for com.sumologic, close and release your repo. 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     group = "com.sumologic.shellbase"
     description = "Sumo Logic's Scala-based interactive shell framework"
 
-    version = '5.0.0'
+    version = '5.0.1'
 
     sourceCompatibility = javaSourceVersion
     targetCompatibility = javaTargetVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,8 @@ javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
 # Scala versions
-supportedScalaVersions = 2.12.19, 2.13.14
-defaultScalaVersion = 2.12.19
+supportedScalaVersions = 2.12.20, 2.13.15
+defaultScalaVersion = 2.12.20
 
 
 # Gradle UI


### PR DESCRIPTION
**What**:
- Switching the Scala versions to latest patches: 2.13.15, 2.12.20
- Releasing 5.0.1

**Why**:
To stay up to date.